### PR TITLE
Migrate trunk to main and retire develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ you've found an error or have a suggestion for a new feature; please, ensure
 that it is reported.
 
 If you would like to contribute a fix or new feature; please, submit a pull
-request.  This project follows [git flow] and utilizes [travis] to automatically
-check pull requests before a manual review.
+request.
 
 # Contributors
 
@@ -27,8 +26,6 @@ copyrights and other information.  If you submit a pull request and would like
 attribution; please, add yourself to the `COPYRIGHT` file.
 
 [siren]: http://amundsen.com/media-types/collection/
-[git flow]: http://nvie.com/posts/a-successful-git-branching-model/
 [Hackage]: https://hackage.haskell.org/package/collection-json
 [Haskell]: https://www.haskell.org/
 [issues]: https://github.com/alunduil/siren-json.hs/issues
-[travis]: https://travis-ci.org/alunduil/siren-json.hs

--- a/siren-json.cabal
+++ b/siren-json.cabal
@@ -27,7 +27,7 @@ extra-source-files:
 source-repository head
   type:     git
   location: https://github.com/alunduil/siren-json.git
-  branch:   develop
+  branch:   main
 
 library
   default-language:    Haskell2010


### PR DESCRIPTION
## Summary

`main` is now the trunk and default branch; `develop` and `master` are gone. In-tree references updated to match.

## Gotchas

- The remote rename (`develop` → `main`), default-branch switch, and `master` deletion happened out-of-band via the GitHub API before this PR was opened. Reviewer doesn't need to verify those — `gh api repos/alunduil/siren-json.hs --jq .default_branch` returns `main` and `gh api repos/alunduil/siren-json.hs/branches` shows only `main` and this feature branch. The diff itself is just the cabal pointer and README scrub.
- `master` had 17 commits not on `develop`, but they were Renovate `renovate/master-*` PR merges duplicating the same dependency bumps already merged on `develop`; content was preserved.
- README's Travis sentence/link were dropped wholesale (not just the branching bit). Travis replacement is tracked separately in #63.

## Verification

- `gh api repos/alunduil/siren-json.hs --jq .default_branch` → `main`
- `gh api repos/alunduil/siren-json.hs/branches --jq '.[].name'` → only `main` (plus this PR's branch)
- Local `git branch -a` shows only `main` tracking `origin/main`

Closes #59