### PR TITLE
Migrate Object construction to Data.Aeson.KeyMap

### DIFF
--- a/siren-json.cabal
+++ b/siren-json.cabal
@@ -46,7 +46,7 @@ library
     , External.Network.HTTP.Types.Method.JSON
 
   build-depends:
-      aeson >=0.8 && <2.3
+      aeson >=2.0 && <2.3
     , base >=4.6 && <4.23
     , bytestring           == 0.10.*
     , containers           == 0.5.*
@@ -55,7 +55,6 @@ library
     , network-uri          == 2.6.*
     , network-uri-json >=0.1 && <0.5
     , text                 == 1.2.*
-    , unordered-containers == 0.2.*
 
   other-extensions:
 
@@ -85,7 +84,7 @@ test-suite siren-json-tests
       hspec-discover:hspec-discover >= 2.4 && < 2.8
 
   build-depends:
-      aeson >=0.8 && <2.3
+      aeson >=2.0 && <2.3
     , base >=4.6 && <4.23
     , bytestring           == 0.10.*
     , containers           == 0.5.*
@@ -99,7 +98,6 @@ test-suite siren-json-tests
     , quickcheck-instances == 0.3.*
     , test-invariant       == 0.4.*
     , text                 == 1.2.*
-    , unordered-containers == 0.2.*
 
   other-extensions:
       OverloadedStrings

--- a/src/Data/SirenJSON.hs
+++ b/src/Data/SirenJSON.hs
@@ -26,7 +26,7 @@ import Network.HTTP.Types (StdMethod (GET))
 import Network.URI.JSON ()
 import Network.URI (URI)
 
-import qualified Data.HashMap.Lazy as HashMap (fromList)
+import qualified Data.Aeson.KeyMap as KeyMap (fromList)
 import qualified Data.Map.Strict as Map (empty, Map, null)
 
 import External.Network.HTTP.Media.MediaType.JSON ()
@@ -89,7 +89,7 @@ instance FromJSON SubEntity where
 
 instance ToJSON SubEntity where
   toJSON (EmbeddedLink l) = toJSON l
-  toJSON EmbeddedRepresentation{..} = Object $ toObject sEntity <> HashMap.fromList ["rel" .= sRel]
+  toJSON EmbeddedRepresentation{..} = Object $ toObject sEntity <> KeyMap.fromList ["rel" .= sRel]
                                       where toObject :: ToJSON a => a -> Object
                                             toObject v = case toJSON v of
                                                            Object o -> o


### PR DESCRIPTION
## Summary

`Data.SirenJSON` now builds against aeson 2.x. The library's only `HashMap`-typed expression — the `Object` construction in `SubEntity`'s `ToJSON` instance — moved to `Data.Aeson.KeyMap`, matching aeson 2.0's retyped `Object`.

Closes #61.

## Gotchas

Local `cabal build`/`cabal test` was verified with `--allow-newer --constraint "aeson < 2.2"`. Two unrelated transitive issues forced this:

- The cabal file's pre-modernisation bounds (`bytestring == 0.10.*`, `containers == 0.5.*`, `text == 1.2.*`) are incompatible with GHC 9.6's boot libs. #62 fixes these.
- `network-uri-json-0.4.0.0` declares orphan `FromJSON URI`/`ToJSON URI` instances, which collide with native instances added in aeson 2.2. The constraint avoids that collision so #61 can be verified in isolation; resolving it (either bumping `network-uri-json` once a 2.2-compatible release exists, or capping `aeson < 2.2`) belongs in #62 alongside the rest of the bound work.

`cabal check` will warn until #62 lands — expected per the issue body.

## Verification

- `cabal build --allow-newer --constraint "aeson < 2.2"` succeeds on GHC 9.6.7 with aeson-2.1.x.
- `cabal test --allow-newer --constraint "aeson < 2.2"` — all 21 examples pass, including round-trip property tests that prove the encoded shape is unchanged.
- `grep -rn "HashMap\|unordered-containers" src/ siren-json.cabal` returns no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)